### PR TITLE
Correct the density and material fraction of the LYSO material

### DIFF
--- a/VoxelisedSimulation/GATESubMacros/GateMaterials.db
+++ b/VoxelisedSimulation/GATESubMacros/GateMaterials.db
@@ -221,11 +221,11 @@ PTFE:   d= 2.18 g/cm3 ; n=2 ; state=solid
         +el: name=Fluorine   ; n=2
 
 
-LYSO:   d=5.37 g/cm3; n=4 ; state=Solid
-        +el: name=Lutetium   ; f=0.31101534
-        +el: name=Yttrium    ; f=0.368765605
-        +el: name=Silicon    ; f=0.083209699
-        +el: name=Oxygen     ; f=0.237009356
+LYSO:   d=7.36 g/cm3; n=4    ; state=Solid
+        +el: name=Lutetium   ; f=0.714467891
+        +el: name=Yttrium    ; f=0.04033805
+        +el: name=Silicon    ; f=0.063714272
+        +el: name=Oxygen     ; f=0.181479788
 
 Body:   d=1.00 g/cm3 ; n=2
         +el: name=Hydrogen   ; f=0.112


### PR DESCRIPTION
It appears that the LYSO material details were incorrect in a pervious version of GATE, see: https://github.com/OpenGATE/GateContrib/blob/e691a3a3600d47b90c0267004d5506ed3be40812/imaging/LUTDavisModel/GateMaterials.db#L223-L233
This PR uses the ammended GATE values.
Also validated against wikipedia: https://en.wikipedia.org/wiki/Lutetium-yttrium_oxyorthosilicate

This lead to issues with singles rates and as consequence coincidence rates. This should go someway to fix #18. Validation of count rates will be discussed there.  