### PR TITLE
Cleanup and Refactors2

### DIFF
--- a/ExamplePhantoms/STIRparFiles/SourceSingleCentralVoxel.par
+++ b/ExamplePhantoms/STIRparFiles/SourceSingleCentralVoxel.par
@@ -6,7 +6,7 @@ Y output image size (in pixels):=110
 Z output image size (in pixels):=65
 X voxel size (in mm):= 4
 Y voxel size (in mm):= 4
-Z voxel size (in mm):= 4.0625
+Z voxel size (in mm):= 4
 
   Z number of samples to take per voxel := 1
   Y number of samples to take per voxel := 1
@@ -17,7 +17,7 @@ Ellipsoid Parameters:=
    radius-x (in mm):=2
    radius-y (in mm):=2
    radius-z (in mm):=2
-   origin (in mm):={130,0,0}
+   origin (in mm):={128,0,0}  ;(z,y,x)
    END:=
 value :=10000
 

--- a/ExampleScanners/D690/root_header_template.hroot
+++ b/ExampleScanners/D690/root_header_template.hroot
@@ -13,7 +13,7 @@ Maximum number of non-arc-corrected bins := 381
 GATE scanner type := GATE_Cylindrical_PET
 GATE_Cylindrical_PET Parameters :=
 
-name of data file := ROOT_OUTPUT_TASK_ID.root
+name of data file := ROOT_FILENAME.root
 
 name of input TChain := Coincidences
 

--- a/ExampleScanners/mMR/root_header_template.hroot
+++ b/ExampleScanners/mMR/root_header_template.hroot
@@ -13,7 +13,7 @@ Maximum number of non-arc-corrected bins := 344
 GATE scanner type := GATE_ECAT_PET
 GATE_ECAT_PET Parameters :=
 
-name of data file := ROOT_OUTPUT_TASK_ID.root
+name of data file := ROOT_FILENAME.root
 
 name of input TChain := Coincidences
 

--- a/VoxelisedSimulation/CheckGeometry.sh
+++ b/VoxelisedSimulation/CheckGeometry.sh
@@ -32,8 +32,10 @@ echo "Script initialised:" $(date +%d.%m.%y-%H:%M:%S)
 ## Copy the relevent the scanner files from ExampleScanners into position for simulation.
 ./SubScripts/PrepareScannerFiles.sh $ScannerType $StoreRootFilesDirectory
 
-./RunGATE.sh $GATEMainMacro $ActivityFilename $AttenuationFilename\
+## The root_filename is not a variable here but a dummy given to RunGATE
+./RunGATE.sh $GATEMainMacro root_filename $ActivityFilename $AttenuationFilename\
 			$StoreRootFilesDirectory $TASK_ID $StartTime $EndTime $QT
 
 echo "Script finished: " $(date +%d.%m.%y-%H:%M:%S)
+
 exit 0

--- a/VoxelisedSimulation/ExampleSTIR-GATE.sh
+++ b/VoxelisedSimulation/ExampleSTIR-GATE.sh
@@ -54,7 +54,10 @@ ROOT_FILENAME=Sim_$TASK_ID
 ## Setup Simulation. Copy files, (possibly generate phantom), and create GATE density map
 ./SetupSimulation.sh $ScannerType $StoreRootFilesDirectory $ActivityFilename $AttenuationFilename
 # ./SetupSimulation.sh $ScannerType $StoreRootFilesDirectory $ActivityPar $AttenuationPar
-
+if [ $? -ne 0 ] ;then
+	echo "Error in SetupSimulation.sh"
+	exit 1
+fi
 
 ##### ==============================================================
 ## RunGATE
@@ -62,14 +65,20 @@ ROOT_FILENAME=Sim_$TASK_ID
 
 ./RunGATE.sh $GATEMainMacro $ROOT_FILENAME $ActivityFilename $AttenuationFilename\
 			$StoreRootFilesDirectory $TASK_ID $StartTime $EndTime
-
+if [ $? -ne 0 ]; then
+	echo "Error in RunGATE.sh"
+	exit 1
+fi
 
 ##### ==============================================================
 ## Unlist GATE data
 ##### ==============================================================
 
 ./SubScripts/UnlistRoot.sh $StoreRootFilesDirectory $ROOT_FILENAME
-
+if [ $? -ne 0 ]; then
+	echo "Error in ./SubScripts/UnlistRoot.sh"
+	exit 1
+fi
 
 echo "Script finished: " `date +%d.%m.%y-%H:%M:%S`
 

--- a/VoxelisedSimulation/ExampleSTIR-GATE.sh
+++ b/VoxelisedSimulation/ExampleSTIR-GATE.sh
@@ -32,6 +32,8 @@ echo "Script initialised:" `date +%d.%m.%y-%H:%M:%S`
 ActivityPar=../ExamplePhantoms/STIRparFiles/SourceSingleCentralVoxel.par
 AttenuationPar=../ExamplePhantoms/STIRparFiles/EmptyAttenuation.par
 
+## This could be done in SetupSimulation.sh but we need the $ActivityFilename and 
+## $AttenuationFilename for this example
 SourceFilenames=`SubScripts/GenerateSTIRGATEImages.sh $ActivityPar $AttenuationPar 2>/dev/null`
 ## Get activity and attenuation filenames from $SourceFilenames
 ActivityFilename=`echo ${SourceFilenames} |awk '{print $1}'`
@@ -50,7 +52,8 @@ ScannerType="D690"  # Scanner type from Examples (eg. D690/mMR).
 ROOT_FILENAME=Sim_$TASK_ID
 
 ## Setup Simulation. Copy files, (possibly generate phantom), and create GATE density map
-./SetupSimulation.sh $ScannerType $StoreRootFilesDirectory $ActivityPar $AttenuationPar
+./SetupSimulation.sh $ScannerType $StoreRootFilesDirectory $ActivityFilename $AttenuationFilename
+# ./SetupSimulation.sh $ScannerType $StoreRootFilesDirectory $ActivityPar $AttenuationPar
 
 
 ##### ==============================================================

--- a/VoxelisedSimulation/ExampleSTIR-GATE.sh
+++ b/VoxelisedSimulation/ExampleSTIR-GATE.sh
@@ -47,7 +47,7 @@ StartTime=0  ## Start time in GATE time
 EndTime=1  ## End time in GATE time
 StoreRootFilesDirectory=Output  ## Save location of root data
 ScannerType="D690"  # Scanner type from Examples (eg. D690/mMR).
-
+ROOT_FILENAME=Sim_$TASK_ID
 
 ## Setup Simulation. Copy files, (possibly generate phantom), and create GATE density map
 ./SetupSimulation.sh $ScannerType $StoreRootFilesDirectory $ActivityPar $AttenuationPar
@@ -57,7 +57,7 @@ ScannerType="D690"  # Scanner type from Examples (eg. D690/mMR).
 ## RunGATE
 ##### ==============================================================
 
-./RunGATE.sh $GATEMainMacro $ActivityFilename $AttenuationFilename\
+./RunGATE.sh $GATEMainMacro $ROOT_FILENAME $ActivityFilename $AttenuationFilename\
 			$StoreRootFilesDirectory $TASK_ID $StartTime $EndTime
 
 
@@ -65,7 +65,7 @@ ScannerType="D690"  # Scanner type from Examples (eg. D690/mMR).
 ## Unlist GATE data
 ##### ==============================================================
 
-./SubScripts/UnlistRoot.sh $StoreRootFilesDirectory $TASK_ID
+./SubScripts/UnlistRoot.sh $StoreRootFilesDirectory $ROOT_FILENAME
 
 
 echo "Script finished: " `date +%d.%m.%y-%H:%M:%S`

--- a/VoxelisedSimulation/MainGATE.mac
+++ b/VoxelisedSimulation/MainGATE.mac
@@ -37,7 +37,7 @@
 ## ROOT LM OUTPUT
 
 /gate/output/root/enable
-/gate/output/root/setFileName            {StoreRootFilesDirectory}/ROOT_OUTPUT_{SimuId}
+/gate/output/root/setFileName            {StoreRootFilesDirectory}/{ROOT_FILENAME}
 /gate/output/root/setRootSinglesAdderFlag   0
 /gate/output/root/setRootSinglesReadoutFlag 0
 /gate/output/root/setRootHitFlag            0

--- a/VoxelisedSimulation/Output/Templates/lm_to_projdata_template.par
+++ b/VoxelisedSimulation/Output/Templates/lm_to_projdata_template.par
@@ -1,7 +1,7 @@
 lm_to_projdata Parameters:=
 
-  input file := root_header_TASK_ID.hroot
-  output filename prefix := Unlisted/UNLISTINGDIRECTORY/sinogram_TASK_ID
+  input file := ROOT_FILENAME.hroot
+  output filename prefix := Unlisted/UNLISTINGDIRECTORY/sinogram_ROOT_FILENAME
 
   ; parameters that determine the sizes etc of the output
        ; template_scanner.hs is delivered by `SubScripts/PrepareScannerFiles.sh`

--- a/VoxelisedSimulation/RunGATE.sh
+++ b/VoxelisedSimulation/RunGATE.sh
@@ -9,8 +9,7 @@
 ## AttenuationTranslation, AtteniationVoxelSize, 
 ## and NumberOfVoxels (attenuation file).
 
-echo $#
-if [ $# -lt 8 ]; then
+if [ $# != 8 ] && [ $# !=9 ]; then
   echo "Error in $0 with number of arguments."
   echo "Usage: $0 GATEMainMacro ROOT_FILENAME ActivityFilename AttenuationFilename SimuId StartTime EndTime [QT]" 1>&2
   exit 1

--- a/VoxelisedSimulation/RunGATE.sh
+++ b/VoxelisedSimulation/RunGATE.sh
@@ -9,25 +9,26 @@
 ## AttenuationTranslation, AtteniationVoxelSize, 
 ## and NumberOfVoxels (attenuation file).
 
-
-if [ $# -lt 7 ]; then
+echo $#
+if [ $# -lt 8 ]; then
   echo "Error in $0 with number of arguments."
-  echo "Usage: $0 GATEMainMacro ActivityFilename AttenuationFilename SimuId StartTime EndTime [QT]" 1>&2
+  echo "Usage: $0 GATEMainMacro ROOT_FILENAME ActivityFilename AttenuationFilename SimuId StartTime EndTime [QT]" 1>&2
   exit 1
 fi
 
 # Parameters for GATE
 GATEMainMacro=$1
-ActivityFilename=$2
-AttenuationFilename=$3
-StoreRootFilesDirectory=$4
-SimuId=$5
-StartTime=$6
-EndTime=$7
+ROOT_FILENAME=$2
+ActivityFilename=$3
+AttenuationFilename=$4
+StoreRootFilesDirectory=$5
+TASK_ID=$6
+StartTime=$7
+EndTime=$8
 
 ## Optional QT visualisation, required seperate GATE setup
 QT=0
-if [ $# == 8 ] && [ $8 == "1" ]
+if [ $# == 9 ] && [ $9 == "1" ]
 then 
 	echo "Gate --qt is ON"
 	QT=1 
@@ -66,7 +67,7 @@ if [ $QT -eq 1 ]; then
 
 	echo "Running Gate with visualisation."
 	Gate --qt $GATEMainMacro -a \
-[SimuId,$SimuId]\
+[SimuId,$TASK_ID][ROOT_FILENAME,$ROOT_FILENAME]\
 [StartTime,$StartTime][EndTime,$EndTime]\
 [StoreRootFilesDirectory,$StoreRootFilesDirectory]\
 [NumberOfVoxelsX,$NumberOfVoxelsX][NumberOfVoxelsY,$NumberOfVoxelsY][NumberOfVoxelsZ,$NumberOfVoxelsZ]\
@@ -79,7 +80,7 @@ else
 
 	echo "Running Gate."
 	Gate $GATEMainMacro -a \
-[SimuId,$SimuId]\
+[SimuId,$TASK_ID][ROOT_FILENAME,$ROOT_FILENAME]\
 [StartTime,$StartTime][EndTime,$EndTime]\
 [StoreRootFilesDirectory,$StoreRootFilesDirectory]\
 [NumberOfVoxelsX,$NumberOfVoxelsX][NumberOfVoxelsY,$NumberOfVoxelsY][NumberOfVoxelsZ,$NumberOfVoxelsZ]\

--- a/VoxelisedSimulation/SetupSimulation.sh
+++ b/VoxelisedSimulation/SetupSimulation.sh
@@ -28,7 +28,10 @@ ATTENUATION=$4
 
 ## Get the scanner files into GATESubMacros directory.
 ./SubScripts/PrepareScannerFiles.sh $ScannerType $StoreRootFilesDirectory
-
+if [ $? -ne 0 ]; then
+	echo "Error in SubScripts/PrepareScannerFiles.sh"
+	exit 1
+fi
 
 # Check extension of ACTIVITY and ATTENUATION
 if [ "${ACTIVITY##*.}" == "par"  ] && [ "${ATTENUATION##*.}" == "par"  ]
@@ -47,11 +50,11 @@ else
 	AttenuationFilename=$ATTENUATION
 fi
 
-# Check AttenuationFilename has extension "h33"
-if [ "${AttenuationFilename##*.}" != "h33"  ]
+# Check ActivityFilename and AttenuationFilename has extension "h33"
+if [ "${ActivityFilename##*.}" != "h33"  ] || [ "${AttenuationFilename##*.}" != "h33"  ]
 then
-	echo "SetupSimulation: AttenuationFilename does not have suffix *.h33"
-	echo $AttenuationFilename
+	echo "SetupSimulation: ActivityFilename and/or AttenuationFilename does not have suffix '*.h33'"
+	echo $ActivityFilename $AttenuationFilename
 	exit 1
 fi
 
@@ -59,3 +62,5 @@ fi
 Gate GATESubMacros/SetupDmap.mac -a [AttenuationFilename,$AttenuationFilename]
 
 echo "SetupSimulation Complete"
+
+exit 0

--- a/VoxelisedSimulation/SubScripts/GenerateSTIRGATEImages.sh
+++ b/VoxelisedSimulation/SubScripts/GenerateSTIRGATEImages.sh
@@ -15,7 +15,7 @@
 if [ $# -ne 2 ]; then
   echo "Usage:"$0 "ActivityPar AttenuationPar" 1>&2
   echo "Returns Activity and Attenuation filenames."
-  exit 0
+  exit 1
 fi
 
 ActivityPar=$1  ## Activity parameter file

--- a/VoxelisedSimulation/SubScripts/ModifyAttenuationImageForGate.sh
+++ b/VoxelisedSimulation/SubScripts/ModifyAttenuationImageForGate.sh
@@ -7,8 +7,8 @@
 ## Voxelised attenuation images are required to be of type int (for segmentation). 
 ## This script takes an interfile image as input and multiplied all values for GATE. 
 
-export input=$1
-export output=$2
+input=$1
+output=$2
 
 if [ $# -ne 2 ]; then
   echo "Error in $0 with number of arguments"

--- a/VoxelisedSimulation/SubScripts/PrepareScannerFiles.sh
+++ b/VoxelisedSimulation/SubScripts/PrepareScannerFiles.sh
@@ -28,6 +28,7 @@ if [ ! -d $StoreRootFilesDirectory/Templates ]; then  # Does the template direct
 	mkdir -p $StoreRootFilesDirectory/Templates
 fi
 
+
 if [ $ScannerType = "D690" ]; then
 	echo "Preparing D690 scanner files"
 	D690_DIR="../ExampleScanners/D690"
@@ -48,6 +49,7 @@ elif [ $ScannerType = "mMR" ]; then
 
 else
 	echo "Invalid scanner name parsed. Please indicate 'D690' or 'mMR'."
+	exit 1
 fi
 
 exit 0

--- a/VoxelisedSimulation/SubScripts/STIR2GATE_interfile.sh
+++ b/VoxelisedSimulation/SubScripts/STIR2GATE_interfile.sh
@@ -12,11 +12,23 @@ if [ $# -ne 2 ]; then
   echo "Usage:"$0 "GATEOutputFilename STIRInputFilename" 1>&2
   echo " - GATEOutputFilename: should have '.h33' suffix."
   echo " - STIRInputFilename: should have '.hv' suffix"
-  exit 0
+  exit 1
 fi
 
 GATEFilename=$1
 STIRFilename=$2
+
+if [ "${GATEFilename##*.}" != "h33"  ]; then
+	echo "Error in STIR2GATE_interfile, the GATEFilename does not end in '*.h33'"
+	echo "GATEFilename = $GATEFilename"
+	exit 1
+fi
+
+if [ "${STIRFilename##*.}" != "hv"  ]; then
+	echo "Error in STIR2GATE_interfile, the STIRFilename does not end in '*.h33'"
+	echo "STIRFilename = $STIRFilename"
+	exit 1
+fi
 
 
 ## Get the number of slices = Number of voxels in z

--- a/VoxelisedSimulation/SubScripts/UnlistRoot.sh
+++ b/VoxelisedSimulation/SubScripts/UnlistRoot.sh
@@ -43,3 +43,4 @@ rm *.bak
 
 lm_to_projdata lm_to_projdata_${ROOT_FILENAME}.par
 
+exit 0

--- a/VoxelisedSimulation/SubScripts/UnlistRoot.sh
+++ b/VoxelisedSimulation/SubScripts/UnlistRoot.sh
@@ -11,7 +11,7 @@
 # - $1: Root files directory
 # - $2: Task_ID
 StoreRootFilesDirectory=$1
-TASK_ID=$2
+ROOT_FILENAME=$2
 
 LowerEnergyThreshold=0
 UpperEngeryThreshold=1000
@@ -19,27 +19,27 @@ UpperEngeryThreshold=1000
 echo "STIR-GATE-connection unlisting"
 
 if [ $# -ne 2 ]; then
-  echo "Usage:"$0 "StoreRootFilesDirectory TASK_ID" 1>&2
+  echo "Usage:"$0 "StoreRootFilesDirectory ROOT_FILENAME" 1>&2
   exit 1
 else
-	echo "Unlisting $StoreRootFilesDirectory/ROOT_OUTPUT_$TASK_ID.root"
+	echo "Unlisting ${StoreRootFilesDirectory}/${ROOT_FILENAME}.root"
 fi
 
 cd $StoreRootFilesDirectory
 
 #============= create parameter file from template =============
-cp  Templates/lm_to_projdata_template.par lm_to_projdata_${TASK_ID}.par
-sed -i.bak "s/TASK_ID/$TASK_ID/g" lm_to_projdata_$TASK_ID.par
-sed -i.bak "s/UNLISTINGDIRECTORY/UnlistedSinograms/g" lm_to_projdata_${TASK_ID}.par
+cp  Templates/lm_to_projdata_template.par lm_to_projdata_${ROOT_FILENAME}.par
+sed -i.bak "s/ROOT_FILENAME/${ROOT_FILENAME}/g" lm_to_projdata_${ROOT_FILENAME}.par
+sed -i.bak "s/UNLISTINGDIRECTORY/UnlistedSinograms/g" lm_to_projdata_${ROOT_FILENAME}.par
 
 
-cp  Templates/root_header_template.hroot  root_header_${TASK_ID}.hroot
-sed -i.bak "s/TASK_ID/${TASK_ID}/g" root_header_${TASK_ID}.hroot
-sed -i.bak "s/LOWTHRES/${LowerEnergyThreshold}/g" root_header_${TASK_ID}.hroot
-sed -i.bak "s/UPTHRES/${UpperEngeryThreshold}/g" root_header_${TASK_ID}.hroot
+cp  Templates/root_header_template.hroot  ${ROOT_FILENAME}.hroot
+sed -i.bak "s/ROOT_FILENAME/${ROOT_FILENAME}/g" ${ROOT_FILENAME}.hroot
+sed -i.bak "s/LOWTHRES/${LowerEnergyThreshold}/g" ${ROOT_FILENAME}.hroot
+sed -i.bak "s/UPTHRES/${UpperEngeryThreshold}/g" ${ROOT_FILENAME}.hroot
 
 rm *.bak
 
 
-lm_to_projdata lm_to_projdata_${TASK_ID}.par
+lm_to_projdata lm_to_projdata_${ROOT_FILENAME}.par
 


### PR DESCRIPTION
- Removes hardcoding of root filename in macros. `$ROOT_FILENAME` is set in the top level, e.g. `ExampleSTIR-GATE.sh`, this can include `$TASK_ID` for unique ID.
- Adds tests on error states.
- Adds some tests on input arguments.
- Centalises the `SourceSingleCentralVoxel.par` in an odd (z) voxelised phantom.

