### PR TITLE
Comment position in par file causes KeyParser error

### DIFF
--- a/ExamplePhantoms/STIRparFiles/EmptyAttenuation.par
+++ b/ExamplePhantoms/STIRparFiles/EmptyAttenuation.par
@@ -1,6 +1,7 @@
-; This parameter file is used to create a volume of with uniform zero value using STIR's `generate_image` utility.
 generate_image Parameters :=
 output filename:=attenuation
+
+; This parameter file is used to create a volume of with uniform zero value using STIR's `generate_image` utility.
 
 X output image size (in pixels):=110
 Y output image size (in pixels):=110

--- a/ExamplePhantoms/STIRparFiles/SourceSingleCentralVoxel.par
+++ b/ExamplePhantoms/STIRparFiles/SourceSingleCentralVoxel.par
@@ -1,6 +1,7 @@
-; This parameter file is used to create a single voxel of activity at the center of the volume using STIR's `generate_image` utility.
 generate_image Parameters :=
 output filename:=activity
+
+; This parameter file is used to create a single voxel of activity at the center of the volume using STIR's `generate_image` utility.
 
 X output image size (in pixels):=110
 Y output image size (in pixels):=110


### PR DESCRIPTION
A KeyParser error occurs when the first line of a par file is a comment as it is unable to find 'required first keyword'.