### PR TITLE
Change the D690 offset (num of detectors) := 0

### DIFF
--- a/ExampleScanners/D690/root_header_template.hroot
+++ b/ExampleScanners/D690/root_header_template.hroot
@@ -54,7 +54,7 @@ exclude random events := {EXCLUDERANDOM}
 ; STIR will try to align the data. 
 ; If you have used non standart GATE axes, 
 ; rotate using: 
-offset (num of detectors) := -8
+offset (num of detectors) := 0
 
 ; If want to deactivate set to [0, 10000]
 low energy window (keV) := {LOWTHRES}


### PR DESCRIPTION
This partially addresses some of the problems found in #59. 

Since the merge of https://github.com/UCL/STIR/pull/181, the use of STIR's `offset (num of detectors)` in the `D690/root_header_template.hroot` is no longer needed, as shown in https://github.com/UCL/STIR-GATE-Connection/issues/59#issuecomment-799277930. The STIR sinogram key `View offset (degrees) :=` now handles the x-y scanner axis rotation between GATE and STIR.

However, care needs to be taken when estimating the normalsation/efficiency factors, see: https://github.com/UCL/STIR-GATE-Connection/issues/59#issuecomment-797445057 for temporaraly modified STIR sinogram header, only used for computing ML norm factors right now.
